### PR TITLE
add make install rule for easier distro integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,12 @@
+prefix ?= /usr/local
+bindir ?= $(prefix)/bin
+DESTDIR ?= /
+
 all:	pcsensor
+
+install: pcsensor
+	test -d $(DESTDIR)$(bindir) || mkdir -p  $(DESTDIR)$(bindir)
+	install -m 755 $^ $(DESTDIR)$(bindir)
 
 CFLAGS = -O2 -Wall
 


### PR DESCRIPTION
thx for considering... hit this when trying to make use of this as part of snappy ubuntu-core snapcraft build system where a make isntall DESTDIR=... is needed to produce the final tree...